### PR TITLE
Prevent infinite loop when catching errors.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -210,7 +210,7 @@ function parser() {
 
   function take() {
     if(errored || !state.length)
-      return errored
+      return false
 
     return (token = tokens[0]) && !stream.paused
   }


### PR DESCRIPTION
If an error is caught, the parser's while loop would continue to run without advancing, as the return value of `take` would always be true.

By always returning false, parsing will stop when an error is raised, caught or otherwise.

Thanks! :)
