### PR TITLE
Handle stream errors gracefully

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,6 +115,7 @@ function parser() {
 
   var stream = through(write, end)
     , check = arguments.length ? [].slice.call(arguments) : []
+    , ended = false
     , depth = 0
     , state = []
     , tokens = []
@@ -266,8 +267,8 @@ function parser() {
       emit = true
     }
 
-    if(emit) stream.emit('data', _node) 
-  
+    if(emit && !errored) stream.emit('data', _node)
+
     node = _node.parent
     return _node
   }
@@ -307,8 +308,8 @@ function parser() {
       return tokens.shift(), state.shift()
     }
     switch(token.type) {
-      case 'eof': return state.shift()
-      case 'keyword': 
+      case 'eof': return got_eof()
+      case 'keyword':
         switch(token.data) {
           case 'for': return state.unshift(forstmt());
           case 'if': return state.unshift(ifstmt());
@@ -344,6 +345,12 @@ function parser() {
         }
       default: return state.unshift(expr(';'))
     }
+  }
+
+  function got_eof() {
+    if (ended) errored = true
+    ended = true
+    return state.shift()
   }
 
   function parse_decl() {
@@ -584,7 +591,14 @@ function parser() {
     return
 
     function parseexpr(tokens) {
-      return full_parse_expr(state, tokens), state.shift()
+      try {
+        full_parse_expr(state, tokens)
+      } catch(err) {
+        stream.emit('error', err)
+        errored = true
+      }
+
+      return state.shift()
     }
   }
 


### PR DESCRIPTION
Now should catch and emit errors from lib/expr.js, avoid infinite loops on unclosed braces, and stop emitting data after running into an error.

Fixes #5, and stops glslify from crashing the workshopper when running into syntax errors. Thanks! :)
